### PR TITLE
remove useless (and not working) type hint

### DIFF
--- a/src/clojure/pantomime/media.clj
+++ b/src/clojure/pantomime/media.clj
@@ -94,7 +94,7 @@
     (.getBaseType input))
   (parameters-of
     [^MediaType input]
-    (when-let [^Map jm (.getParameters input)]
+    (when-let [jm (.getParameters input)]
       (into {} jm)))
   (has-parameters?
     [^MediaType input]


### PR DESCRIPTION
The type-hint probably refers to java.util.Map, which is not automatically imported in clojure.
While this compiles fine as of clojure 1.5.1, this is only because the compiler ignores the wrong type hint.

The type-hint was actually useless so I just removed it and now it's possible to analyze this library with tools.analyzer.

Found using eastwood.
