### PR TITLE
Expose Tika's Parser interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ MIME types using several techniques:
 
 and so on.
 
+Pantomime also exposes Tika's ability to extract file metadata and
+text content.
+
 
 ## Maven Artifacts
 
@@ -156,7 +159,30 @@ Note that Tika (and, in turn, Pantomime) supports detection of a limited number
 of languages. To get the list of supported languages, use the `pantomime.languages/supported-languages`
 var.
 
+### Metadata and Text Extraction
 
+`pantomime.extact` provides the single function `parse` for extracting
+metadata and text content from byte arrays, Strings, and
+java.io.InputStream, java.net.URL, and java.io.File instances.
+
+``` clojure
+(require '[clojure.java.io :as io] '[pantomime.extract :as extract])
+
+(pprint (extract/parse (io/resource "resources/pdf/qrl.pdf")))
+
+;= {:producer ("GNU Ghostscript 7.05"),
+;=  :pdf:pdfversion ("1.2"),
+;=  :dc:title ("main.dvi"),
+;=  :dc:format ("application/pdf; version=1.2"),
+;=  :xmp:creatortool ("dvips(k) 5.86 Copyright 1999 Radical Eye Software"),
+;=  :pdf:encrypted ("false"),
+;=  ...
+;=  :text "\nQuickly Reacquirable Locks∗\n\nDave Dice Mark Moir ... "
+;= }
+```
+
+`extract/parse` is a simple interface to Tika's own
+[Parser.parse method](https://tika.apache.org/1.7/parser.html).
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -161,14 +161,17 @@ var.
 
 ### Metadata and Text Extraction
 
-`pantomime.extact` provides the single function `parse` for extracting
-metadata and text content from byte arrays, Strings, and
-java.io.InputStream, java.net.URL, and java.io.File instances.
+`pantomime.extract` provides the single function `parse` for extracting
+metadata and text content from byte arrays, java.io.InputStream and
+java.net.URL instances as well as filenames as strings and
+java.io.File instances.
+
+An example:
 
 ``` clojure
 (require '[clojure.java.io :as io] '[pantomime.extract :as extract])
 
-(pprint (extract/parse (io/resource "resources/pdf/qrl.pdf")))
+(pprint (extract/parse "test/resources/pdf/qrl.pdf"))
 
 ;= {:producer ("GNU Ghostscript 7.05"),
 ;=  :pdf:pdfversion ("1.2"),
@@ -179,6 +182,14 @@ java.io.InputStream, java.net.URL, and java.io.File instances.
 ;=  ...
 ;=  :text "\nQuickly Reacquirable Locks∗\n\nDave Dice Mark Moir ... "
 ;= }
+```
+
+If extraction fails, `extract.parse` will return the following:
+
+``` clojure
+{:text "",
+ :content-type ("application/octet-stream"),
+ :x-parsed-by ("org.apache.tika.parser.EmptyParser")}
 ```
 
 `extract/parse` is a simple interface to Tika's own

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,9 @@
   :license { :name "Eclipse Public License" }
   :source-paths ["src/clojure"]
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.apache.tika/tika-core "1.7"]]
+                 [org.apache.tika/tika-core "1.7"]
+                 [org.apache.tika/tika-parsers "1.7"]
+                 [byte-streams "0.2.0-alpha8"]]
   :profiles {:dev {:resource-paths ["test/resources"]
                    :dependencies [[clj-http "1.0.1"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0-alpha5"]]}

--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,7 @@
   :source-paths ["src/clojure"]
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.apache.tika/tika-core "1.7"]
-                 [org.apache.tika/tika-parsers "1.7"]
-                 [byte-streams "0.2.0-alpha8"]]
+                 [org.apache.tika/tika-parsers "1.7"]]
   :profiles {:dev {:resource-paths ["test/resources"]
                    :dependencies [[clj-http "1.0.1"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0-alpha5"]]}

--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,7 @@
   :description "A tiny Clojure library that deals with MIME types"
   :license { :name "Eclipse Public License" }
   :source-paths ["src/clojure"]
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.apache.tika/tika-core "1.7"]
+  :dependencies [[org.clojure/clojure "1.6.0"]                 
                  [org.apache.tika/tika-parsers "1.7"]]
   :profiles {:dev {:resource-paths ["test/resources"]
                    :dependencies [[clj-http "1.0.1"]]}

--- a/src/clojure/pantomime/extract.clj
+++ b/src/clojure/pantomime/extract.clj
@@ -1,0 +1,43 @@
+(ns pantomime.extract
+  (:import [java.io File InputStream]
+           [org.apache.tika Tika]
+           [java.net URL]
+           [org.apache.tika.metadata Metadata]
+           [org.apache.tika.sax BodyContentHandler]
+           [org.apache.tika.parser Parser AutoDetectParser ParseContext])
+  (:require [byte-streams :as bs])
+  (:use [clojure.java.io :only [input-stream]]))
+
+(defn conv-metadata [^Metadata mdata]
+  (let [names (.names mdata)]
+    (zipmap (map #(keyword (.toLowerCase %1)) names)
+            (map #(seq (.getValues mdata %1)) names))))
+
+(def ^{:private true} tika-class (Tika.))
+
+(defprotocol ExtractionOps
+  (parse [input] "Extract content and metadata"))
+
+(extend-protocol ExtractionOps
+  InputStream
+  (parse [^InputStream ifile]
+         (let [parser   (AutoDetectParser.)
+               context  (ParseContext.)
+               metadata (Metadata.)
+               handler  (BodyContentHandler. -1)]
+           (.set context Parser parser)
+           (.parse parser ifile handler metadata context)
+           (assoc (conv-metadata metadata) :text (.toString handler)))))
+  
+(extend-protocol ExtractionOps
+  java.io.File
+  (parse [^File file] (with-open [is (input-stream file)] (parse is))))
+  
+;; XXX this is, sadly, not working
+(extend-protocol ExtractionOps
+  String
+  (parse [^String contents] (parse (bs/to-input-stream contents))))
+                             
+(extend-protocol ExtractionOps
+  URL
+  (parse [^URL url] (with-open [is (input-stream url)] (parse is))))

--- a/src/clojure/pantomime/extract.clj
+++ b/src/clojure/pantomime/extract.clj
@@ -1,11 +1,11 @@
 (ns pantomime.extract
-  (:import [java.io File InputStream]
+  (:require [pantomime.internal :refer :all])            
+  (:import [java.io File InputStream ByteArrayInputStream]
            [org.apache.tika Tika]
            [java.net URL]
            [org.apache.tika.metadata Metadata]
            [org.apache.tika.sax BodyContentHandler]
            [org.apache.tika.parser Parser AutoDetectParser ParseContext])
-  (:require [byte-streams :as bs])
   (:use [clojure.java.io :only [input-stream]]))
 
 (defn conv-metadata [^Metadata mdata]
@@ -21,23 +21,35 @@
 (extend-protocol ExtractionOps
   InputStream
   (parse [^InputStream ifile]
-         (let [parser   (AutoDetectParser.)
-               context  (ParseContext.)
-               metadata (Metadata.)
-               handler  (BodyContentHandler. -1)]
-           (.set context Parser parser)
-           (.parse parser ifile handler metadata context)
-           (assoc (conv-metadata metadata) :text (.toString handler)))))
+    (let [parser   (AutoDetectParser.)
+          context  (ParseContext.)
+          metadata (Metadata.)
+          handler  (BodyContentHandler. -1)]
+      (.set context Parser parser)
+      (.parse parser ifile handler metadata context)
+      (assoc (conv-metadata metadata) :text (.toString handler)))))
   
 (extend-protocol ExtractionOps
   java.io.File
   (parse [^File file] (with-open [is (input-stream file)] (parse is))))
-  
-;; XXX this is, sadly, not working
+
+;; thanks
+;; https://clojuredocs.org/clojure.core/xml-seq#example-542692d6c026201cdc3270ca
+;; and https://nukelight.wordpress.com/2012/02/12/xml-parsing-in-clojure/
+;; for hints about String->InputStream, and that parsers seem to like
+;; ByteArrayInputStream rather than InputStream
 (extend-protocol ExtractionOps
-  String
-  (parse [^String contents] (parse (bs/to-input-stream contents))))
+  String  
+  (parse [^String contents]
+    (parse
+     (ByteArrayInputStream.
+      (.getBytes (.trim contents))))))
                              
 (extend-protocol ExtractionOps
   URL
   (parse [^URL url] (with-open [is (input-stream url)] (parse is))))
+
+(extend byte-array-type  
+  ExtractionOps
+  {:parse (fn [^bytes input]
+            (parse (ByteArrayInputStream. input)))})

--- a/src/clojure/pantomime/extract.clj
+++ b/src/clojure/pantomime/extract.clj
@@ -1,5 +1,5 @@
 (ns pantomime.extract
-  (:require [pantomime.internal :refer :all])            
+  (:require [pantomime.internal :refer :all])
   (:import [java.io File InputStream ByteArrayInputStream]
            [org.apache.tika Tika]
            [java.net URL]
@@ -39,17 +39,20 @@
 ;; for hints about String->InputStream, and that parsers seem to like
 ;; ByteArrayInputStream rather than InputStream
 (extend-protocol ExtractionOps
-  String  
-  (parse [^String contents]
-    (parse
-     (ByteArrayInputStream.
-      (.getBytes (.trim contents))))))
+  String
+  (parse [^String filename]
+    (with-open [is (input-stream filename)] (parse is))))
+
+  ;; (parse [^String contents]
+  ;;   (parse
+  ;;    (ByteArrayInputStream.
+  ;;     (.getBytes (.trim contents))))))
                              
 (extend-protocol ExtractionOps
   URL
   (parse [^URL url] (with-open [is (input-stream url)] (parse is))))
 
-(extend byte-array-type  
+(extend byte-array-type
   ExtractionOps
   {:parse (fn [^bytes input]
             (parse (ByteArrayInputStream. input)))})

--- a/test/pantomime/test/extract_test.clj
+++ b/test/pantomime/test/extract_test.clj
@@ -1,0 +1,56 @@
+(ns pantomime.test.extract-test
+  (:require [clojure.java.io   :as io]
+            [pantomime.extract :as extract]
+            [clojure.test      :refer :all])
+  (:import [java.io File FileInputStream]
+           java.net.URL))
+
+
+(deftest test-extract-pdf-metadata
+  (let [parsed (extract/parse (io/resource "resources/pdf/qrl.pdf"))]
+    (are [x y] (= (x parsed) (list y))
+         :pdf:pdfversion  "1.2"
+         :dc:title        "main.dvi")))
+
+(deftest test-extract-pdf-metadata-stream
+  (let [parsed (extract/parse (io/input-stream (io/resource "resources/pdf/qrl.pdf")))]
+    (are [x y] (= (x parsed) (list y))
+         :pdf:pdfversion  "1.2"
+         :dc:title        "main.dvi")))
+
+(deftest test-extract-pdf-metadata-file
+  (let [parsed (extract/parse (io/as-file (io/resource "resources/pdf/qrl.pdf")))]
+    (are [x y] (= (x parsed) (list y))
+         :pdf:pdfversion  "1.2"
+         :dc:title        "main.dvi")))
+
+;; failing.
+;; http://stackoverflow.com/questions/7181658/byte-collection-to-string-on-clojure
+;; http://alexander-hill.tumblr.com/post/88883810180/working-with-binary-files-in-clojure
+;; https://github.com/ztellman/byte-streams
+(deftest test-extract-pdf-metadata-string
+  (let [file-path "test/resources/pdf/qrl.pdf"]
+    (with-open [reader (io/input-stream file-path)]
+      (let [length  (.length (clojure.java.io/file file-path))
+            buffer  (byte-array length)
+            _       (.read reader buffer 0 length)
+            content (apply str (map #(char (bit-and % 255)) buffer))
+            parsed  (extract/parse content)]
+        (are [x y] (= (x parsed) (list y))
+             :pdf:pdfversion  "1.2"
+             :dc:title        "main.dvi")))))
+            
+(deftest test-extract-text-contents
+  (let [test-file    "resources/txt/english.txt"
+        parsed       (extract/parse (io/resource test-file))
+        ;; frustratingly, tika.sax.BodyContentHandler or
+        ;; tika.parser.txt.TXTParser seems to add a newline to the end
+        ;; of the file contents.
+        file-content (str (slurp (str "test/" test-file)) "\n")]
+    (is (= (:text parsed) file-content))))
+
+(deftest test-extract-jpg
+  (let [parsed (extract/parse (io/resource "resources/images/feather-small.gif"))]
+    (are [x y] (= (x parsed) y)
+         :text   ""
+         (keyword "compression lossless") (list "true"))))

--- a/test/pantomime/test/extract_test.clj
+++ b/test/pantomime/test/extract_test.clj
@@ -1,56 +1,74 @@
 (ns pantomime.test.extract-test
   (:require [clojure.java.io   :as io]
             [pantomime.extract :as extract]
+            [clj-http.client :as http]
             [clojure.test      :refer :all])
   (:import [java.io File FileInputStream]
            java.net.URL))
 
 
-(deftest test-extract-pdf-metadata
-  (let [parsed (extract/parse (io/resource "resources/pdf/qrl.pdf"))]
+(deftest test-extract-metadata
+  (let [parsed (->  "resources/pdf/qrl.pdf"
+                    io/resource
+                    extract/parse)]                    
     (are [x y] (= (x parsed) (list y))
          :pdf:pdfversion  "1.2"
          :dc:title        "main.dvi")))
 
-(deftest test-extract-pdf-metadata-stream
-  (let [parsed (extract/parse (io/input-stream (io/resource "resources/pdf/qrl.pdf")))]
+(deftest test-extract-metadata-input-stream
+  (let [parsed (-> "resources/pdf/qrl.pdf"
+                   io/resource
+                   io/input-stream
+                   extract/parse)]
     (are [x y] (= (x parsed) (list y))
          :pdf:pdfversion  "1.2"
          :dc:title        "main.dvi")))
 
-(deftest test-extract-pdf-metadata-file
-  (let [parsed (extract/parse (io/as-file (io/resource "resources/pdf/qrl.pdf")))]
+(deftest test-extract-metadata-file
+  (let [parsed (-> "resources/pdf/qrl.pdf"
+                   io/resource
+                   io/as-file
+                   extract/parse)]
     (are [x y] (= (x parsed) (list y))
          :pdf:pdfversion  "1.2"
          :dc:title        "main.dvi")))
 
-;; failing.
 ;; http://stackoverflow.com/questions/7181658/byte-collection-to-string-on-clojure
 ;; http://alexander-hill.tumblr.com/post/88883810180/working-with-binary-files-in-clojure
 ;; https://github.com/ztellman/byte-streams
-(deftest test-extract-pdf-metadata-string
-  (let [file-path "test/resources/pdf/qrl.pdf"]
-    (with-open [reader (io/input-stream file-path)]
+(deftest test-extract-metadata-byte-array
+  (let [file-path "test/resources/pdf/qrl.pdf"]  
+    (with-open [reader (io/input-stream (io/file file-path))]
       (let [length  (.length (clojure.java.io/file file-path))
             buffer  (byte-array length)
-            _       (.read reader buffer 0 length)
-            content (apply str (map #(char (bit-and % 255)) buffer))
-            parsed  (extract/parse content)]
+            _       (.read reader buffer 0 length)            
+            parsed  (extract/parse buffer)]
         (are [x y] (= (x parsed) (list y))
              :pdf:pdfversion  "1.2"
              :dc:title        "main.dvi")))))
-            
+
+(deftest test-extract-metadata-string    
+  (let [test-file    "resources/txt/english.txt"
+        parsed       (-> test-file
+                         io/resource
+                         slurp
+                         extract/parse)]
+    (are [x y] (= (x parsed) (list y))
+         :content-encoding "ISO-8859-1")))
+         
 (deftest test-extract-text-contents
   (let [test-file    "resources/txt/english.txt"
-        parsed       (extract/parse (io/resource test-file))
-        ;; frustratingly, tika.sax.BodyContentHandler or
-        ;; tika.parser.txt.TXTParser seems to add a newline to the end
-        ;; of the file contents.
-        file-content (str (slurp (str "test/" test-file)) "\n")]
+        parsed       (-> test-file
+                         io/resource
+                         slurp
+                         extract/parse)        
+        file-content (slurp (str "test/" test-file))]
     (is (= (:text parsed) file-content))))
 
-(deftest test-extract-jpg
-  (let [parsed (extract/parse (io/resource "resources/images/feather-small.gif"))]
-    (are [x y] (= (x parsed) y)
-         :text   ""
-         (keyword "compression lossless") (list "true"))))
+(deftest test-extract-URL
+  (let [parsed (-> "https://www.rabbitmq.com/resources/specs/amqp0-9-1.pdf"
+                   io/as-url
+                   extract/parse)]
+    (are [x y] (= (x parsed) (list y))
+         :pdf:pdfversion  "1.4"
+         :dc:title        "Advanced Message Queuing Protocol Specification")))

--- a/test/pantomime/test/extract_test.clj
+++ b/test/pantomime/test/extract_test.clj
@@ -10,7 +10,7 @@
 (deftest test-extract-metadata
   (let [parsed (->  "resources/pdf/qrl.pdf"
                     io/resource
-                    extract/parse)]                    
+                    extract/parse)]
     (are [x y] (= (x parsed) (list y))
          :pdf:pdfversion  "1.2"
          :dc:title        "main.dvi")))
@@ -37,33 +37,28 @@
 ;; http://alexander-hill.tumblr.com/post/88883810180/working-with-binary-files-in-clojure
 ;; https://github.com/ztellman/byte-streams
 (deftest test-extract-metadata-byte-array
-  (let [file-path "test/resources/pdf/qrl.pdf"]  
+  (let [file-path "test/resources/pdf/qrl.pdf"]
     (with-open [reader (io/input-stream (io/file file-path))]
       (let [length  (.length (clojure.java.io/file file-path))
             buffer  (byte-array length)
-            _       (.read reader buffer 0 length)            
+            _       (.read reader buffer 0 length)
             parsed  (extract/parse buffer)]
         (are [x y] (= (x parsed) (list y))
              :pdf:pdfversion  "1.2"
              :dc:title        "main.dvi")))))
 
-(deftest test-extract-metadata-string    
-  (let [test-file    "resources/txt/english.txt"
-        parsed       (-> test-file
-                         io/resource
-                         slurp
-                         extract/parse)]
+(deftest test-extract-metadata-string
+  (let [parsed (extract/parse "test/resources/txt/english.txt")]
     (are [x y] (= (x parsed) (list y))
          :content-encoding "ISO-8859-1")))
-         
+
 (deftest test-extract-text-contents
   (let [test-file    "resources/txt/english.txt"
-        parsed       (-> test-file
-                         io/resource
-                         slurp
-                         extract/parse)        
+        parsed       (extract/parse "test/resources/txt/english.txt")
         file-content (slurp (str "test/" test-file))]
-    (is (= (:text parsed) file-content))))
+    ;; org.apache.tika.parser.txt.TXTParser (I think) adds a newline
+    ;; to parsed text :/
+    (is (= (:text parsed) (str file-content "\n")))))
 
 (deftest test-extract-URL
   (let [parsed (-> "https://www.rabbitmq.com/resources/specs/amqp0-9-1.pdf"


### PR DESCRIPTION
Hello-

I've added metadata and text extraction support to panomime, based on the [clj-tika](https://github.com/alexott/clj-tika) code. I wrote a few tests and updated the README.

Usage is straightforward, as seen in the README- just call `(extract/parse resource)`, where `resource` is any of the file/stream-like things that `mime-type-of` supports. The one difference is how it handles Strings- instead of treating them as a path to a file, it treats them as parseable data.

Thanks!