### PR TITLE
Pattern addition support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.novemberain/pantomime "2.8.0-SNAPSHOT"
+(defproject lupapiste/pantomime "2.8.0-SNAPSHOT"
   :min-lein-version "2.5.1"
   :description "A minimalistic Clojure interface to Apache Tika"
   :url "http://github.com/michaelklishin/pantomime"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lupapiste/pantomime "2.8.0-SNAPSHOT"
+(defproject com.novemberain/pantomime "2.8.0-SNAPSHOT"
   :min-lein-version "2.5.1"
   :description "A minimalistic Clojure interface to Apache Tika"
   :url "http://github.com/michaelklishin/pantomime"

--- a/src/clojure/pantomime/mime.clj
+++ b/src/clojure/pantomime/mime.clj
@@ -79,8 +79,8 @@
 (defn add-pattern
   "Adds a new MimeType pattern to pantomime"
   [name pattern test]
-  (when-not (and (= name (mime-type-of test))
-                 (nil? mime-adder))
+  {:pre  [(not= name (mime-type-of test))]
+   :post [(= name (mime-type-of test))]}
+  (when-not (nil? mime-adder)
     (let [mime-type (.forName mime-adder name)]
-      (.addPattern mime-adder mime-type pattern true))
-      (assert (= name (mime-type-of test)))))
+      (.addPattern mime-adder mime-type pattern true))))

--- a/src/clojure/pantomime/mime.clj
+++ b/src/clojure/pantomime/mime.clj
@@ -69,15 +69,18 @@
     (catch MimeTypeException _
       "")))
 
-(def ^MimeTypes factory (-> detector
-                            .getDetector
-                            .getDetectors
-                            last))
+(def ^MimeTypes mime-adder
+  (->> detector
+       .getDetector
+       .getDetectors
+       (filter #(instance? org.apache.tika.mime.MimeTypes %))
+       first))
 
 (defn add-pattern
   "Adds a new MimeType pattern to pantomime"
   [name pattern test]
-  (when-not (= name (mime-type-of test))
-    (let [mime-type (.forName factory name)]
-      (.addPattern factory mime-type pattern true))
+  (when-not (and (= name (mime-type-of test))
+                 (nil? mime-adder))
+    (let [mime-type (.forName mime-adder name)]
+      (.addPattern mime-adder mime-type pattern true))
       (assert (= name (mime-type-of test)))))

--- a/src/clojure/pantomime/mime.clj
+++ b/src/clojure/pantomime/mime.clj
@@ -68,3 +68,16 @@
     "")
     (catch MimeTypeException _
       "")))
+
+(def ^MimeTypes factory (-> detector
+                            .getDetector
+                            .getDetectors
+                            last))
+
+(defn add-pattern
+  "Adds a new MimeType pattern to pantomime"
+  [name pattern test]
+  (when-not (= name (mime-type-of test))
+    (let [mime-type (.forName factory name)]
+      (.addPattern factory mime-type pattern true))
+      (assert (= name (mime-type-of test)))))

--- a/test/pantomime/test/mime_test.clj
+++ b/test/pantomime/test/mime_test.clj
@@ -64,3 +64,8 @@
     "application/xhtml+xml"    ".xhtml"
     "application/octet-stream" ".bin"
     "g-d/knows/what"           ""))
+
+(deftest test-adding-pattern
+  (is (= (mime-type-of "lorem.ipsum") "application/octet-stream")) ; fallback mime type
+  (add-pattern "text/lorem-ipsum" ".+\\.ipsum$" "lorem.ipsum")
+  (is (= (mime-type-of "lorem.ipsum") "text/lorem-ipsum")))


### PR DESCRIPTION
The code in this pull request is mainly from the snippet by @dwwoelfel in issues back in 2013, I just fixed it a bit and wrote a simple test. So if @dwwoelfel would like to take the code below and wrap it in a pull request of his own, I'd be fine with that. :)

I'd just like to see this change in master asap as we are going to be using it production shortly and I'd prefer it comes from the main pantomime codebase instead of my forked project.

Example of usage:
```
(add-pattern "text/foobar" ".+\\.foo$" "testfilename.foo")
```
...which adds a new mime type `text/foobar` which matches to files with a `.foo` extension.