### PR TITLE
More actual versions of libraries to make pantomime JDK 9-compatible

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,16 +1,16 @@
-(defproject com.novemberain/pantomime "2.10.0-SNAPSHOT"
+(defproject com.novemberain/pantomime "2.10.0"
   :min-lein-version "2.5.1"
   :description "A minimalistic Clojure interface to Apache Tika"
   :url "http://github.com/michaelklishin/pantomime"
   :license { :name "Eclipse Public License" }
   :source-paths ["src/clojure"]
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.apache.tika/tika-parsers "1.14"]
-                 [org.apache.commons/commons-compress "1.14"]]
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [org.apache.tika/tika-parsers "1.17"]
+                 [org.apache.commons/commons-compress "1.15"]]
   :profiles {:dev {:resource-paths ["test/resources"]
-                   :dependencies [[clj-http "3.4.1"]]}
+                   :dependencies [[clj-http "3.7.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
-             :master {:dependencies [[org.clojure/clojure "1.9.0-master-SNAPSHOT"]]}}
+             :master {:dependencies [[org.clojure/clojure "1.9.0"]]}}
   :repositories {"sonatype" {:url "http://oss.sonatype.org/content/repositories/releases"
                              :snapshots false
                              :releases {:checksum :fail :update :always}}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.novemberain/pantomime "2.10.0"
+(defproject com.novemberain/pantomime "2.10.0-SNAPSHOT"
   :min-lein-version "2.5.1"
   :description "A minimalistic Clojure interface to Apache Tika"
   :url "http://github.com/michaelklishin/pantomime"


### PR DESCRIPTION
Just an update in project.clj
wit the more actual versions, pantomime can be used with Java 9 and Clojure 1.9