### PR TITLE
Object rec and embedded

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.github.tsukiji86/pantomime "2.10.1"
+(defproject com.novemberain/pantomime "2.10.1"
   :min-lein-version "2.5.1"
   :description "A minimalistic Clojure interface to Apache Tika"
   :url "http://github.com/michaelklishin/pantomime"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.github.tsukiji86/pantomime "2.10.0"
+(defproject com.github.tsukiji86/pantomime "2.10.1"
   :min-lein-version "2.5.1"
   :description "A minimalistic Clojure interface to Apache Tika"
   :url "http://github.com/michaelklishin/pantomime"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.novemberain/pantomime "2.10.0"
+(defproject com.github.tsukiji86/pantomime "2.10.0"
   :min-lein-version "2.5.1"
   :description "A minimalistic Clojure interface to Apache Tika"
   :url "http://github.com/michaelklishin/pantomime"
@@ -6,6 +6,7 @@
   :source-paths ["src/clojure"]
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.apache.tika/tika-parsers "1.17"]
+                 [org.apache.tika/tika-dl "1.17"]
                  [org.apache.commons/commons-compress "1.15"]]
   :profiles {:dev {:resource-paths ["test/resources"]
                    :dependencies [[clj-http "3.7.0"]]}

--- a/src/clojure/pantomime/extract.clj
+++ b/src/clojure/pantomime/extract.clj
@@ -39,9 +39,8 @@
       (let [tmp-fh           (File/createTempFile "pantomime-" "-embedded")
             meta             {:path (.getPath ^File tmp-fh)
                               :name (.get ^Metadata metadata "resourceName")}]
-        (do
-          (copy stream tmp-fh)
-          (swap! embedded-meta conj meta))))))
+        (copy stream tmp-fh)
+        (swap! embedded-meta conj meta)))))
 
 (defn embed-parser
   "Parser for parsing embedded documents.  Rolls up name-value pairs into parent metadata."

--- a/test/pantomime/test/extract_test.clj
+++ b/test/pantomime/test/extract_test.clj
@@ -56,15 +56,6 @@
     ;; org.apache.tika.parser.txt.TXTParser (I think) adds a newline
     ;; to parsed text :/
     (is (= (:text parsed) (str file-content "\n")))))
-
-(deftest test-extract-embedded
-  (let [parsed       (extract/parse-extract-embedded
-                      "test/resources/pdf/fileAttachment.pdf")
-        embedded     (:path (first (:embedded parsed)))
-        embedded-parsed (extract/parse embedded)
-        _            (io/delete-file embedded)]
-    (are [x y] (= (x embedded-parsed) (list y))
-         :content-type     "application/x-123")))
          
 (deftest test-extract-URL
   (let [parsed (-> "https://www.rabbitmq.com/resources/specs/amqp0-9-1.pdf"

--- a/test/pantomime/test/extract_test.clj
+++ b/test/pantomime/test/extract_test.clj
@@ -56,6 +56,15 @@
     ;; org.apache.tika.parser.txt.TXTParser (I think) adds a newline
     ;; to parsed text :/
     (is (= (:text parsed) (str file-content "\n")))))
+
+(deftest test-extract-embedded
+  (let [parsed       (extract/parse-extract-embedded
+                       "test/resources/pdf/fileAttachment.pdf")
+        embedded     (:path (first (:embedded parsed)))
+        embedded-parsed (extract/parse embedded)
+        _            (io/delete-file embedded)]
+    (are [x y] (= (x embedded-parsed) (list y))
+               :content-type     "application/x-123")))
          
 (deftest test-extract-URL
   (let [parsed (-> "https://www.rabbitmq.com/resources/specs/amqp0-9-1.pdf"


### PR DESCRIPTION
Some modifications I made for a project I'm involved in to add the tika dl4j object recognition library tied with the parsers and to add a method to roll embedded items metadata up into parent metadata while parsing, thought it may be useful to others.  In particular, adds the object recognition results into the parent metadata rather than solely putting the results in the extracted text of the BodyContentHandler.